### PR TITLE
Address some warnings

### DIFF
--- a/nimassets.nimble
+++ b/nimassets.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.2.0"
 author        = "xmonader"
 description   = "bundle your assets to a nim"
 license       = "MIT"
@@ -10,7 +10,7 @@ bin           = @["nimassets"]
 
 # Dependencies
 
-requires "nim >= 0.19.0"
+requires "nim >= 1.4.0"
 
 task assetsBin, "Build nimassets":
     exec "nimble build --threads:on"


### PR DESCRIPTION
Here they all are:
```
--- from this repo:

…/src/nimassets.nim(1, 48) Warning: imported and not used: 'strutils' [UnusedImport]
…/src/nimassets.nim(1, 12) Warning: imported and not used: 'tables' [UnusedImport]

…/src/nimassets.nim(1, 39) Warning: import os.nim instead; ospaths is deprecated [Deprecated]

--- from consuming project:

…/src/views/assets_file.nim(1, 8)  Warning: imported and not used: 'os' [UnusedImport]
…/src/views/assets_file.nim(1, 20) Warning: imported and not used: 'strformat' [UnusedImport]

…/src/views/assets_file.nim(8, 8)  Warning: Deprecated since v1.4; it was more confusing than useful, use `[]=`; add is deprecated [Deprecated]
```